### PR TITLE
Allow developers to use a custom web port for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# Application Configuration
 APP_NAME="Seymour RSS"
 APP_ENV=local
 APP_KEY=
@@ -5,19 +6,23 @@ APP_DEBUG=true
 APP_URL=http://seymour.test
 APP_LOCALE=en
 
+# Log Configuration
 LOG_CHANNEL=stack
 LOG_LEVEL=debug
 
+# Database Configuration
 DB_CONNECTION=sqlite
-DB_DATABASE=laravel
+DB_DATABASE=/var/www/storage/app/seymour.sqlite
 
+# General Configuration
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file
 QUEUE_CONNECTION=sync
 SESSION_DRIVER=database
 SESSION_LIFETIME=120
 
-MAIL_MAILER=smtp
+# Mail Configuration
+MAIL_MAILER=log
 MAIL_HOST=mailhog
 MAIL_PORT=1025
 MAIL_USERNAME=null
@@ -25,3 +30,6 @@ MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
 MAIL_FROM_ADDRESS=null
 MAIL_FROM_NAME="${APP_NAME}"
+
+# Local Docker Configuration
+LOCAL_WEB_PORT=80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       context: docker/nginx
     # command: ['nginx-debug']
     ports:
-      - "${APP_PORT}:80"
+      - "${LOCAL_WEB_PORT}:80"
     volumes:
       - ./:/var/www:cached
     depends_on:


### PR DESCRIPTION
This PR adds a `LOCAL_WEB_PORT` option to the `.env` file that allows developers
to specify which host port they want to map to the http container port 80. 
