### PR TITLE
Add Phrase Translation Helper

### DIFF
--- a/app/Actions/Feeds/SubscribeToFeed.php
+++ b/app/Actions/Feeds/SubscribeToFeed.php
@@ -19,7 +19,7 @@ class SubscribeToFeed extends Action
     public $subscription;
 
     /**
-     * Handle the action.
+     * Subscribe a user to a feed.
      *
      * @param Action|array $input
      * @return self
@@ -104,6 +104,9 @@ class SubscribeToFeed extends Action
      */
     public function required()
     {
-        return ['user', 'url'];
+        return [
+            'user', // User
+            'url' // string
+        ];
     }
 }

--- a/app/Actions/Feeds/SubscribeToFeed.php
+++ b/app/Actions/Feeds/SubscribeToFeed.php
@@ -41,7 +41,9 @@ class SubscribeToFeed extends Action
 
         // Dispatch job for storing articles...
 
-        return $this->complete(Phrase::SUBSCRIPTION_CREATED);
+        return $this->complete(Phrase::translate('SUBSCRIPTION_CREATED', [
+            'title' => $this->subscription->title,
+        ]));
     }
 
     /**

--- a/app/Actions/Feeds/UnsubscribeFromFeed.php
+++ b/app/Actions/Feeds/UnsubscribeFromFeed.php
@@ -24,7 +24,9 @@ class UnsubscribeFromFeed extends Action
 
         $this->subscription->delete();
 
-        return $this->complete(Phrase::SUBSCRIPTION_REMOVED);
+        return $this->complete(Phrase::translate('SUBSCRIPTION_REMOVED', [
+            'title' => $this->subscription->title,
+        ]));
     }
 
     /**

--- a/app/Feeds/Exceptions/InvalidXmlException.php
+++ b/app/Feeds/Exceptions/InvalidXmlException.php
@@ -29,7 +29,7 @@ class InvalidXmlException extends Exception
      */
     public function __construct($xml, array $errors = [])
     {
-        parent::__construct(Phrase::ATTEMPTED_INVALID_XML);
+        parent::__construct(Phrase::translate('ATTEMPTED_INVALID_XML'));
 
         $this->errors = $errors;
         $this->invalidXml = $xml;

--- a/app/Feeds/Exceptions/UnknownFeedVariantException.php
+++ b/app/Feeds/Exceptions/UnknownFeedVariantException.php
@@ -21,7 +21,7 @@ class UnknownFeedVariantException extends Exception
      */
     public function __construct($xml)
     {
-        parent::__construct(Phrase::UNKNOWN_FEED_VARIANT);
+        parent::__construct(Phrase::translate('UNKNOWN_FEED_VARIANT'));
 
         $this->invalidXml = $xml;
     }

--- a/app/Feeds/Reader.php
+++ b/app/Feeds/Reader.php
@@ -46,7 +46,7 @@ class Reader {
 
         if ($response->failed()) {
             $reader->hasHttpError = $response->failed();
-            $reader->message = Phrase::FEED_HTTP_ERROR;
+            $reader->message = Phrase::translate('FEED_HTTP_ERROR');
             Log::notice("Http Client Error: GET '{$url}' returned a {$response->status()} response.");
             return $reader;
         }

--- a/app/Utilities/Phrase.php
+++ b/app/Utilities/Phrase.php
@@ -17,4 +17,18 @@ class Phrase
     // Subscriptions
     const SUBSCRIPTION_CREATED = "You have been subscribed to ':title'";
     const SUBSCRIPTION_REMOVED = "You have been unsubscribed from ':title'";
+
+    /**
+     * Localize a language constant defined in this class. Defers to the
+     * translation helper provided by Laravel.
+     *
+     * @param string $key
+     * @param array $replace
+     * @param string|null $locale
+     * @return string
+     */
+    public static function translate($key, $replace = [], $locale = null)
+    {
+        return trans(constant('self::' . $key), $replace, $locale);
+    }
 }

--- a/tests/Unit/Actions/Feeds/UnsubscribeFromFeedTest.php
+++ b/tests/Unit/Actions/Feeds/UnsubscribeFromFeedTest.php
@@ -30,7 +30,10 @@ class UnsubscribeFromFeedTest extends TestCase
         ]);
 
         $this->assertTrue($action->completed());
-        $this->assertEquals(Phrase::SUBSCRIPTION_REMOVED, $action->getMessage());
+        $expectedMessage = Phrase::translate('SUBSCRIPTION_REMOVED', [
+            'title' => $subscription->title,
+        ]);
+        $this->assertEquals($expectedMessage, $action->getMessage());
         $this->assertCount(0, $user->subscriptions);
     }
 }


### PR DESCRIPTION
This PR adds a `translate` method to the Phrase utility class.  Wherever
possible we will have this application handle localization for messages related
to domain logic right away, rather than waiting to perform localization from
within a view template.  This will ensure that we can insert message parameters
without having to pass the parameter values into the view templates. 

I am not yet happy with the API of the translation method here.  It would be nice
to be able to refer to the constants directly, without using strings, but the
visual for that is a bit muddy: 

```php
Phrase::tranlsate(Phrase::SUBSCRIPTION_CREATED, [
   'title' => 'Some Subscription Title',
]);
```

We may be able to iterate on this a bit down the road. 
