### PR TITLE
Adjust Logging Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /public/storage
 /storage/*.key
 /storage/parcel
+/storage/app/*
 /vendor
 .env
 .env.backup

--- a/app/Console/Commands/InitializationCommand.php
+++ b/app/Console/Commands/InitializationCommand.php
@@ -39,9 +39,17 @@ class InitializationCommand extends Command
      */
     public function handle()
     {
-        if (! Storage::exists(storage_path('app/seymour.sqlite'))) {
+        if (! Storage::exists('seymour.sqlite')) {
             touch(storage_path('app/seymour.sqlite'));
             Artisan::call('migrate');
+        }
+
+        if (! Storage::exists('public')) {
+            Storage::makeDirectory('public');
+        }
+
+        if (!Storage::exists('logs')) {
+            Storage::makeDirectory('logs');
         }
 
         return 0;

--- a/config/logging.php
+++ b/config/logging.php
@@ -49,7 +49,7 @@ return [
 
         'daily' => [
             'driver' => 'daily',
-            'path' => storage_path('logs/seymour.log'),
+            'path' => storage_path('app/logs/seymour.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => 14,
         ],

--- a/storage/app/.gitignore
+++ b/storage/app/.gitignore
@@ -1,3 +1,0 @@
-*
-!public/
-!.gitignore

--- a/storage/app/public/.gitignore
+++ b/storage/app/public/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
My goal is to organize all application files that only pertain to an individual
running instance of the application to a single folder; this will allow us to
use a single volume mount in the docker command that will host this application
in production.

This PR moves the log file location into the `storage/app/logs` folder. It also
tweaks the "initialization" command placeholder to include scaffolding for the
contents of the `storage/app` folder; we will have to assume that the mounted
volume is empty when the application is first initialized. 
