### PR TITLE
Ensure feed timestamps are stored as UTC.

### DIFF
--- a/app/Actions/Feeds/RecordArticle.php
+++ b/app/Actions/Feeds/RecordArticle.php
@@ -28,9 +28,16 @@ class RecordArticle extends Action
      */
     public function handle($input = [])
     {
+        // Convert the entry timestamp to UTC if present.
+        $timestamp = $input['entry']->getTimestamp();
+        if ($timestamp) {
+            $timestamp->timezone('UTC')->format('Y-m-d H:i:s');
+        }
+
+        // Create a new article.
         $this->article = Article::create([
             'content' => $input['entry']->getContent(),
-            'entry_timestamp' => $input['entry']->getTimestamp(),
+            'entry_timestamp' => $timestamp,
             'identifier' => $input['entry']->getIdentifier(),
             'link_to_source' => $input['entry']->getLinkToSource(),
             'rights' => $input['entry']->getRights(),

--- a/app/Actions/Feeds/SubscribeToFeed.php
+++ b/app/Actions/Feeds/SubscribeToFeed.php
@@ -90,6 +90,11 @@ class SubscribeToFeed extends Action
             return $this->fail($fetch->message);
         }
 
+        $timestamp = $fetch->feed->getTimestamp();
+        if ($timestamp) {
+            $timestamp->timezone('UTC');
+        }
+
         $this->subscription = $user->subscriptions()->create([
             'identifier' => $fetch->feed->getIdentifier(),
             'slug' => Str::slug($fetch->feed->getTitle()),
@@ -100,7 +105,7 @@ class SubscribeToFeed extends Action
             'link_to_source' => $fetch->feed->getLinkToSource(),
             'license' => $fetch->feed->getLicense(),
             'rights' => $fetch->feed->getRights(),
-            'feed_timestamp' => $fetch->feed->getTimestamp(),
+            'feed_timestamp' => $timestamp,
             'variant' => $fetch->feed->getVariant(),
             'extra' => [
                 'authors' => $fetch->feed->getAuthors()->toArray()

--- a/app/Feeds/Entry.php
+++ b/app/Feeds/Entry.php
@@ -160,7 +160,21 @@ abstract class Entry
      */
     public function getTimestamp()
     {
-        return $this->timestamp;
+        return $this->timestamp
+            ? $this->timestamp->clone()
+            : null;
+    }
+
+    /**
+     * Get the entry's timestamp as a string.
+     *
+     * @return string
+     */
+    public function getRawTimestamp()
+    {
+        return $this->timestamp
+            ? $this->timestamp->toIso8601String()
+            : '';
     }
 
     /**

--- a/app/Feeds/Feed.php
+++ b/app/Feeds/Feed.php
@@ -206,7 +206,21 @@ abstract class Feed
      */
     public function getTimestamp()
     {
-        return $this->timestamp;
+        return $this->timestamp
+            ? $this->timestamp->clone()
+            : null;
+    }
+
+    /**
+     * Get the feed timestamp as a string.
+     *
+     * @return string
+     */
+    public function getRawTimestamp()
+    {
+        return $this->timestamp
+            ? $this->timestamp->toIso8601String()
+            : '';
     }
 
     /**

--- a/app/Feeds/Interpreter.php
+++ b/app/Feeds/Interpreter.php
@@ -57,8 +57,6 @@ class Interpreter
         $attributes = $xml->attributes();
         $namespaces = $xml->getDocNamespaces();
 
-        // dd($root, $attributes, $namespaces);
-
         // Check for RSS 0.90
         if ($root == 'RDF' && Str::contains(Arr::get($namespaces, ''), 'rdf/simple/0.9')) {
             return Variants::RSS090;

--- a/app/Feeds/Simulator.php
+++ b/app/Feeds/Simulator.php
@@ -111,7 +111,7 @@ class Simulator
         $entry['linkToSource'] = Arr::get($attributes, 'linkToSource', $this->faker->url());
         $entry['summary'] = Arr::get($attributes, 'summary', $this->faker->sentence());
         $entry['title'] = Arr::get($attributes, 'title', $this->faker->sentence());
-        $entry['timestamp'] = Arr::get($attributes, 'timestamp', now());
+        $entry['timestamp'] = Arr::get($attributes, 'timestamp', now()->subWeek(1));
 
         $this->entries[] = $entry;
 

--- a/app/Utilities/Xml.php
+++ b/app/Utilities/Xml.php
@@ -136,7 +136,7 @@ class Xml
                 return Carbon::parse($value);
             }
         } catch (\Throwable $th) {
-            throw $th;
+            // we will ignore any parsing problems and return null instead.
         }
 
         return null;

--- a/tests/Unit/Actions/Feeds/RecordArticleTest.php
+++ b/tests/Unit/Actions/Feeds/RecordArticleTest.php
@@ -63,4 +63,69 @@ class RecordArticleTest extends TestCase
         ];
         $this->assertEquals($expectedLink, $action->article->getExtra('links')[0]);
     }
+
+    /** @test */
+    public function it_requires_an_entry()
+    {
+        $user = User::factory()->create();
+        $subscription = Subscription::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $action = RecordArticle::execute([
+            'subscription' => $subscription,
+        ]);
+
+        $this->assertFalse($action->completed());
+    }
+
+    /** @test */
+    public function it_requires_a_subscription()
+    {
+        $knownDate = Carbon::create(2020, 1, 1, 12);
+        $author = new Author('Grace Hopper', 'grace@example.com', 'example.com');
+        $firstEntryDate = $knownDate->copy()->subDays(1);
+        Carbon::setTestNow($knownDate);
+        $fake = Simulator::make()->withEntry([
+            'authors' => [$author],
+            'content' => 'Content 1',
+            'identifier' => 'guid1',
+            'linkToSource' => 'example.com/link',
+            'title' => 'Example Entry Title',
+            'summary' => 'Summary 1',
+            'timestamp' => $firstEntryDate,
+        ])->as(Variants::ATOM100);
+        Reader::fake($fake);
+        $feed = Reader::fetch($fake->getUrl())->feed;
+
+        $action = RecordArticle::execute([
+            'entry' => $feed->getEntries()->first(),
+        ]);
+
+        $this->assertFalse($action->completed());
+    }
+
+    /** @test */
+    public function it_records_timestamps_as_utc()
+    {
+        $user = User::factory()->create();
+        $subscription = Subscription::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $knownDate = Carbon::create(2020, 1, 1, 12, 0, 0, "America/Los_Angeles");
+        $fake = Simulator::make()->withEntry([
+            'timestamp' => $knownDate,
+        ])->as(Variants::ATOM100);
+        Reader::fake($fake);
+        $feed = Reader::fetch($fake->getUrl())->feed;
+
+        $action = RecordArticle::execute([
+            'entry' => $feed->getEntries()->first(),
+            'subscription' => $subscription,
+        ]);
+
+        $this->assertTrue($action->completed());
+        $this->assertTrue($action->article->entry_timestamp->eq($knownDate->clone()->timezone('UTC')));
+        $this->assertEquals('UTC', $action->article->entry_timestamp->timezone->getName());
+    }
 }

--- a/tests/Unit/Actions/Feeds/UpdateSubscriptionDefinitionTest.php
+++ b/tests/Unit/Actions/Feeds/UpdateSubscriptionDefinitionTest.php
@@ -34,7 +34,7 @@ class UpdateSubscriptionDefinitionTest extends TestCase
             'rights' => 'copyright',
             'subtitle' => 'This is Atom 1.0',
             'title' => 'New Feed Title',
-            'updated' => $knownDate,
+            'timestamp' => $knownDate,
         ])->as(Variants::ATOM100);
         Reader::fake($fake);
         $fetch = Reader::fetch('example.com/feed');

--- a/tests/Unit/Feeds/SimulatedFeedReaderTest.php
+++ b/tests/Unit/Feeds/SimulatedFeedReaderTest.php
@@ -62,7 +62,7 @@ class SimulatedFeedReaderTest extends TestCase
                 'subtitle' => 'This is RSS 0.90',
                 'identifier' => '0123456789',
                 'linkToSource' => 'example.com',
-                'updated' => $knownDate,
+                'timestamp' => $knownDate,
             ])
             ->withEntry([
                 'linkToSource' => 'example.com/link',
@@ -104,7 +104,7 @@ class SimulatedFeedReaderTest extends TestCase
                 'rights' => 'copyright',
                 'subtitle' => 'This is RSS 0.91',
                 'title' => 'Example Feed',
-                'updated' => $knownDate,
+                'timestamp' => $knownDate,
             ])
             ->withEntry([
                 'linkToSource' => 'example.com/link',
@@ -151,7 +151,7 @@ class SimulatedFeedReaderTest extends TestCase
             'rights' => 'copyright',
             'subtitle' => 'This is RSS 1.0',
             'title' => 'Example Feed',
-            'updated' => $knownDate,
+            'timestamp' => $knownDate,
         ])
             ->withEntry([
                 'linkToSource' => 'example.com/link',
@@ -198,7 +198,7 @@ class SimulatedFeedReaderTest extends TestCase
             'rights' => 'copyright',
             'subtitle' => 'This is RSS 2.0',
             'title' => 'Example Feed',
-            'updated' => $knownDate,
+            'timestamp' => $knownDate,
         ])
             ->withEntry([
                 'identifier' => 'guid1',
@@ -260,7 +260,7 @@ class SimulatedFeedReaderTest extends TestCase
             'rights' => 'copyright',
             'subtitle' => 'This is Atom 1.0',
             'title' => 'Example Feed',
-            'updated' => $knownDate,
+            'timestamp' => $knownDate,
         ])
             ->withEntry([
                 'authors' => [$author],


### PR DESCRIPTION
We should assume that the timestamps received from feeds could be listed in any timezone; let's make sure they are always stored in the database as UTC. 