### PR TITLE
Capture categories from feeds

### DIFF
--- a/app/Feeds/Atom100/Entry.php
+++ b/app/Feeds/Atom100/Entry.php
@@ -5,6 +5,7 @@ namespace App\Feeds\Atom100;
 use App\Feeds\Author;
 use App\Feeds\Entry as ParentEntry;
 use App\Feeds\Variants;
+use App\Utilities\Arr;
 use App\Utilities\Xml;
 use Illuminate\Support\Carbon;
 use SimpleXMLElement;
@@ -37,7 +38,9 @@ class Entry extends ParentEntry
         // Categories
         $categories = collect();
         foreach($this->xml->category as $category) {
-            $categories->push(ucwords((string)$category['term']));
+            $attributes = Xml::attributes($category);
+            $label = Arr::get($attributes, 'label') ?? Arr::get($attributes, 'term');
+            $categories->push(ucwords($label));
         }
         if ($categories->filter()->isNotEmpty()) {
             $this->setExtra('categories', $categories->filter()->toArray());

--- a/app/Feeds/Atom100/Fake.php
+++ b/app/Feeds/Atom100/Fake.php
@@ -39,9 +39,14 @@ class Fake extends FakeFeed
             <updated>{$this->simulator->timestamp->toAtomString()}</updated>
         FEED;
 
+        // Categories
+        foreach($this->simulator->categories as $category) {
+            $feed .= "<category term=\"{$category}\" />\n";
+        }
+
         // Authors
         foreach ($this->simulator->authors as $author) {
-            $feed .= "\n<author>";
+            $feed .= "<author>";
             if ($name = $author->getName()) {
                 $feed .= "<name>{$name}</name>";
             }
@@ -51,7 +56,7 @@ class Fake extends FakeFeed
             if ($uri = $author->getUri()) {
                 $feed .= "<uri>{$uri}</uri>";
             }
-            $feed .= "</author>";
+            $feed .= "</author>\n";
         }
 
         // Entries
@@ -59,12 +64,7 @@ class Fake extends FakeFeed
             $feed .= $this->entryToString($entry);
         }
 
-        $feed .= <<<FEED
-
-        </feed>
-        FEED;
-
-        return $feed;
+        return $feed .= "</feed>";
     }
 
     /**
@@ -75,6 +75,7 @@ class Fake extends FakeFeed
      */
     protected function entryToString(array $entry): string {
         $authors = Arr::get($entry, 'authors', []);
+        $categories = Arr::get($entry, 'categories', []);
         $content = Arr::get($entry, 'content');
         $identifier = Arr::get($entry, 'identifier');
         $linkToSource = Arr::get($entry, 'linkToSource');
@@ -96,9 +97,14 @@ class Fake extends FakeFeed
             </content>
         ENTRY;
 
+        // Categories
+        foreach($categories as $category) {
+            $entry .= "<category term=\"{$category}\" />\n";
+        }
+
         // Authors
         foreach ($authors as $author) {
-            $entry .= "\n<author>";
+            $entry .= "<author>";
             if ($name = $author->getName()) {
                 $entry .= "<name>{$name}</name>";
             }
@@ -108,9 +114,9 @@ class Fake extends FakeFeed
             if ($uri = $author->getUri()) {
                 $entry .= "<uri>{$uri}</uri>";
             }
-            $entry .= "</author>";
+            $entry .= "</author>\n";
         }
 
-        return $entry .= '</entry>';
+        return $entry .= "</entry>\n";
     }
 }

--- a/app/Feeds/Atom100/Feed.php
+++ b/app/Feeds/Atom100/Feed.php
@@ -5,6 +5,7 @@ namespace App\Feeds\Atom100;
 use App\Feeds\Author;
 use App\Feeds\Feed as ParentFeed;
 use App\Feeds\Variants;
+use App\Utilities\Arr;
 use App\Utilities\Xml;
 use Illuminate\Support\Carbon;
 
@@ -31,6 +32,17 @@ class Feed extends ParentFeed
                 Xml::decode($person->email),
                 Xml::decode($person->uri),
             ));
+        }
+
+        // Categories
+        $categories = collect();
+        foreach ($this->xml->category as $category) {
+            $attributes = Xml::attributes($category);
+            $label = Arr::get($attributes, 'label') ?? Arr::get($attributes, 'term');
+            $categories->push(ucwords($label));
+        }
+        if ($categories->filter()->isNotEmpty()) {
+            $this->setExtra('categories', $categories->filter()->toArray());
         }
 
         // Links

--- a/app/Feeds/Feed.php
+++ b/app/Feeds/Feed.php
@@ -2,6 +2,7 @@
 
 namespace App\Feeds;
 
+use App\Utilities\Arr;
 use App\Utilities\Xml;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -62,6 +63,39 @@ abstract class Feed
     public function getEntries(): Collection
     {
         return empty($this->entries) ? collect() : $this->entries;
+    }
+
+    /**
+     * @var array
+     */
+    protected $extra = [];
+
+    /**
+     * Retrieve extra information that may have been parsed from the XML.
+     *
+     * @param string|null $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public function getExtra($key = null, $default = null): mixed
+    {
+        if ($key) {
+            return Arr::get($this->extra, $key, $default);
+        }
+
+        return $this->extra;
+    }
+
+    /**
+     * Record an 'extra' value that was parsed from the XML.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     */
+    public function setExtra($key, $value): void
+    {
+        $this->extra[$key] = $value;
     }
 
     /**

--- a/app/Feeds/Rss200/Fake.php
+++ b/app/Feeds/Rss200/Fake.php
@@ -37,6 +37,10 @@ class Fake extends FakeFeed
             <copyright>{$this->simulator->rights}</copyright>
         FEED;
 
+        foreach ($this->simulator->categories as $category) {
+            $feed .= "<category>{$category}</category>\n";
+        }
+
         foreach ($this->simulator->entries as $entry) {
             $feed .= $this->entryToString($entry);
         }
@@ -59,6 +63,7 @@ class Fake extends FakeFeed
     protected function entryToString(array $entry): string
     {
         $authors = Arr::get($entry, 'authors', []);
+        $categories = Arr::get($entry, 'categories', []);
         $identifier = Arr::get($entry, 'identifier');
         $linkToSource = Arr::get($entry, 'linkToSource');
         $summary = Arr::get($entry, 'summary');
@@ -74,8 +79,12 @@ class Fake extends FakeFeed
             <guid>{$identifier}</guid>
         ENTRY;
 
+        foreach($categories as $category) {
+            $entry .= "<category>{$category}</category>";
+        }
+
         foreach ($authors as $author) {
-            $entry .= "<author>{$author->getEmail()}</author>";
+            $entry .= "<author>{$author->getEmail()}</author>\n";
         }
 
         return $entry .= '</item>';

--- a/app/Feeds/Rss200/Feed.php
+++ b/app/Feeds/Rss200/Feed.php
@@ -20,6 +20,15 @@ class Feed extends ParentFeed
         $this->subtitle = Xml::decode($this->xml->channel[0]->description);
         $this->title = Xml::decode($this->xml->channel[0]->title);
 
+        // Categories
+        $categories = collect();
+        foreach ($this->xml->channel[0]->category as $category) {
+            $categories->push(ucwords(Xml::decode($category)));
+        }
+        if ($categories->isNotEmpty()) {
+            $this->setExtra('categories', $categories->toArray());
+        }
+
         // Links
         $this->linkToSource = Xml::links($this->xml->channel[0])
             ->whereIn('rel', ['none', 'alternate'])

--- a/app/Feeds/Simulator.php
+++ b/app/Feeds/Simulator.php
@@ -20,6 +20,11 @@ class Simulator
     /**
      * @var array
      */
+    public $categories = [];
+
+    /**
+     * @var array
+     */
     public $entries = [];
 
     /**
@@ -84,6 +89,7 @@ class Simulator
         $feed = new Simulator;
 
         $feed->authors = Arr::get($attributes, 'authors', []);
+        $feed->categories = Arr::get($attributes, 'categories', []);
         $feed->identifier = Arr::get($attributes, 'identifier', $feed->faker->uuid());
         $feed->linkToSource = Arr::get($attributes, 'linkToSource', $feed->faker->url);
         $feed->linkToFeed = Arr::get($attributes, 'linkToFeed', $feed->faker->url);
@@ -106,6 +112,7 @@ class Simulator
         $entry = [];
 
         $entry['authors'] = Arr::get($attributes, 'authors', []);
+        $entry['categories'] = Arr::get($attributes, 'categories', []);
         $entry['content'] = Arr::get($attributes, 'content', $this->faker->randomHtml());
         $entry['identifier'] = Arr::Get($attributes, 'identifier', $this->faker->uuid());
         $entry['linkToSource'] = Arr::get($attributes, 'linkToSource', $this->faker->url());

--- a/app/Utilities/Xml.php
+++ b/app/Utilities/Xml.php
@@ -12,6 +12,40 @@ use SimpleXMLElement;
 class Xml
 {
     /**
+     * Retrieve the value of an attribute on a SimpleXMLElement
+     *
+     * @param SimpleXMLElement $xml
+     * @param string $key
+     * @param string|null $ns
+     * @return mixed|null
+     */
+    public static function attributes($xml, $key = '', $ns = null)
+    {
+        // Attempt to cast the @attributes value to an array
+        $object = $xml->attributes($ns, true);
+        $arr = (array)$object;
+
+        $attributes = [];
+        if (array_key_exists('@attributes', $arr)) {
+            // If there is an '@attributes' key available we are good to go
+            $attributes = $arr['@attributes'];
+        } else {
+            // Otherwise fetch the attributes directly from this xml element
+            foreach (iterator_to_array($object) as $key => $value) {
+                $attributes[$key] = self::decode($value);
+            }
+        }
+
+        // If have been given a key attempt to return that attribute value
+        if (!empty($key)) {
+            return Arr::get($attributes, $key, null);
+        }
+
+        // Otherwise return the entire attributes array.
+        return $attributes;
+    }
+
+    /**
      * If a SimpleXMLElement is empty we can assume that it either didn't exist
      * in the first place or that there is nothing of interest to us anyway.
      *
@@ -101,10 +135,8 @@ class Xml
         $links = collect();
 
         foreach ($xml->{$key} as $element) {
-            $attributes = [];
-            foreach (iterator_to_array($element->attributes()) as $key => $value) {
-                $attributes[$key] = self::decode($value);
-            }
+            // Retrieve the attributes from this element.
+            $attributes = self::attributes($element);
 
             // If the attributes array is empty the link may be an XML value.
             if (! Arr::has($attributes, 'href') && $href = self::decode($xml->{$key})) {

--- a/tests/Unit/Feeds/SimulatedFeedReaderTest.php
+++ b/tests/Unit/Feeds/SimulatedFeedReaderTest.php
@@ -193,6 +193,7 @@ class SimulatedFeedReaderTest extends TestCase
         Carbon::setTestNow($knownDate);
         $author = new Author('Grace Hopper', 'grace@example.com', 'example.com');
         $fake = Simulator::make([
+            'categories' => ['cat1', 'cat2'],
             'identifier' => '0123456789',
             'linkToSource' => 'example.com',
             'rights' => 'copyright',
@@ -201,6 +202,7 @@ class SimulatedFeedReaderTest extends TestCase
             'timestamp' => $knownDate,
         ])
             ->withEntry([
+                'categories' => ['cat3', 'cat4'],
                 'identifier' => 'guid1',
                 'linkToSource' => 'example.com/link',
                 'title' => 'Example Entry Title',
@@ -227,20 +229,22 @@ class SimulatedFeedReaderTest extends TestCase
         $this->assertEquals('This is RSS 2.0', $feed->getSubtitle());
         $this->assertTrue($knownDate->equalTo($feed->getTimestamp()));
         $this->assertEquals('Example Feed', $feed->getTitle());
+        $this->assertEquals(['Cat1', 'Cat2'], $feed->getExtra('categories'));
         $entries = $feed->getEntries();
         $this->assertCount(2, $entries);
+        $this->assertEmpty($entries[0]->getAuthors());
         $this->assertEmpty($entries[0]->getContent());
         $this->assertEquals('guid1', $entries[0]->getIdentifier());
         $this->assertEquals('example.com/link', $entries[0]->getLinkToSource());
         $this->assertEquals('Summary 1', $entries[0]->getSummary());
         $this->assertEquals('Example Entry Title', $entries[0]->getTitle());
-        $this->assertEmpty($entries[0]->getAuthors());
+        $this->assertEquals(['Cat3', 'Cat4'], $entries[0]->getExtra('categories'));
         $this->assertEmpty($entries[1]->getContent());
+        $this->assertInstanceOf(Author::class, $entries[1]->getAuthors()->first());
         $this->assertEquals('guid2', $entries[1]->getIdentifier());
         $this->assertEquals('example.com/link/2', $entries[1]->getLinkToSource());
         $this->assertEquals('Summary 2', $entries[1]->getSummary());
         $this->assertEquals('Example Entry Title 2', $entries[1]->getTitle());
-        $this->assertInstanceOf(Author::class, $entries[1]->getAuthors()->first());
         $this->assertEquals('grace@example.com', $entries[1]->getAuthors()->first()->getName());
     }
 
@@ -254,6 +258,7 @@ class SimulatedFeedReaderTest extends TestCase
         Carbon::setTestNow($knownDate);
         $fake = Simulator::make([
             'authors' => [$author],
+            'categories' => ['cat1', 'cat2'],
             'identifier' => '0123456789',
             'linkToSource' => 'example.com',
             'linkToFeed' => 'example.com/feed',
@@ -264,6 +269,7 @@ class SimulatedFeedReaderTest extends TestCase
         ])
             ->withEntry([
                 'authors' => [$author],
+                'categories' => ['cat3', 'cat4'],
                 'content' => 'Content 1',
                 'identifier' => 'guid1',
                 'linkToSource' => 'example.com/link',
@@ -286,6 +292,7 @@ class SimulatedFeedReaderTest extends TestCase
 
         $feed = $result->feed;
         $this->assertNotEmpty($feed->getIdentifier());
+        $this->assertEquals(['Cat1', 'Cat2'], $feed->getExtra('categories'));
         $this->assertEquals('example.com', $feed->getLinkToSource());
         $this->assertEquals('This is Atom 1.0', $feed->getSubtitle());
         $this->assertTrue($knownDate->equalTo($feed->getTimestamp()));
@@ -298,6 +305,8 @@ class SimulatedFeedReaderTest extends TestCase
 
         $entries = $feed->getEntries();
         $this->assertCount(2, $entries);
+
+        $this->assertEquals(['Cat3', 'Cat4'], $entries[0]->getExtra('categories'));
         $this->assertEquals('guid1', $entries[0]->getIdentifier());
         $this->assertEquals('example.com/link', $entries[0]->getLinkToSource());
         $this->assertEquals('Summary 1', $entries[0]->getSummary());


### PR DESCRIPTION
This PR updates the feed parsers to extract 'category' values from RSS 2.0 and
ATOM 1.0 feeds and store them as 'extra' values on the parsed feeds and entries.
