### PR TITLE
More category capture for Subscriptions and Articles

### DIFF
--- a/app/Actions/Feeds/RecordArticle.php
+++ b/app/Actions/Feeds/RecordArticle.php
@@ -47,10 +47,17 @@ class RecordArticle extends Action
             'title' => $input['entry']->getTitle(),
         ]);
 
+        // Authors
         if ($input['entry']->getAuthors()->isNotEmpty()) {
             $this->article->setExtra('authors', $input['entry']->getAuthors()->toArray());
         }
 
+        // Categories
+        if ($input['entry']->hasExtra('categories')) {
+            $this->article->setExtra('categories', $input['entry']->getExtra('categories'));
+        }
+
+        // Links
         if ($links = $input['entry']->getExtra('links')) {
             $this->article->setExtra('links', $links->toArray());
         }

--- a/app/Actions/Feeds/UpdateSubscriptionDefinition.php
+++ b/app/Actions/Feeds/UpdateSubscriptionDefinition.php
@@ -63,6 +63,11 @@ class UpdateSubscriptionDefinition extends Action
             $this->subscription->setExtra('authors', $this->feed->getAuthors()->toArray());
         }
 
+        // Categories
+        if ($this->feed->hasExtra('categories')) {
+            $this->subscription->setExtra('categories', $this->feed->getExtra('categories'));
+        }
+
         // Image
         if ($this->feed->hasExtra('image')) {
             $this->subscription->setExtra('image', $this->feed->getExtra('image'));

--- a/app/Concerns/HasExtras.php
+++ b/app/Concerns/HasExtras.php
@@ -2,8 +2,6 @@
 
 namespace App\Concerns;
 
-use App\Utilities\Arr;
-
 trait HasExtras
 {
     /**
@@ -28,7 +26,7 @@ trait HasExtras
     public function getExtra($key = null, $default = null): mixed
     {
         if ($key) {
-            return Arr::get($this->extra, $key, $default);
+            return data_get($this->extra, $key, $default);
         }
 
         return $this->extra;

--- a/app/Feeds/Atom100/Entry.php
+++ b/app/Feeds/Atom100/Entry.php
@@ -7,8 +7,6 @@ use App\Feeds\Entry as ParentEntry;
 use App\Feeds\Variants;
 use App\Utilities\Arr;
 use App\Utilities\Xml;
-use Illuminate\Support\Carbon;
-use SimpleXMLElement;
 
 class Entry extends ParentEntry
 {

--- a/app/Feeds/Entry.php
+++ b/app/Feeds/Entry.php
@@ -2,14 +2,16 @@
 
 namespace App\Feeds;
 
+use App\Feeds\HasExtrasArray;
 use App\Feeds\Modules;
-use App\Utilities\Arr;
 use App\Utilities\Xml;
 use Illuminate\Support\Collection;
 use SimpleXMLElement;
 
 abstract class Entry
 {
+    use HasExtrasArray;
+
     /**
      * @var Collection
      */
@@ -38,39 +40,6 @@ abstract class Entry
     public function getContent(): string
     {
         return $this->content;
-    }
-
-    /**
-     * @var array
-     */
-    protected $extra = [];
-
-    /**
-     * Retrieve extra information that may have been parsed from the XML.
-     *
-     * @param string|null $key
-     * @param mixed $default
-     * @return mixed
-     */
-    public function getExtra($key = null, $default = null): mixed
-    {
-        if ($key) {
-            return data_get($this->extra, $key, $default);
-        }
-
-        return $this->extra;
-    }
-
-    /**
-     * Record an 'extra' value that was parsed from the XML.
-     *
-     * @param string $key
-     * @param mixed $value
-     * @return void
-     */
-    public function setExtra($key, $value): void
-    {
-        $this->extra = data_set($this->extra, $key, $value);
     }
 
     /**

--- a/app/Feeds/Feed.php
+++ b/app/Feeds/Feed.php
@@ -2,7 +2,7 @@
 
 namespace App\Feeds;
 
-use App\Utilities\Arr;
+use App\Feeds\HasExtrasArray;
 use App\Utilities\Xml;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -10,6 +10,8 @@ use SimpleXMLElement;
 
 abstract class Feed
 {
+    use HasExtrasArray;
+
     /**
      * @var Collection
      */
@@ -63,50 +65,6 @@ abstract class Feed
     public function getEntries(): Collection
     {
         return empty($this->entries) ? collect() : $this->entries;
-    }
-
-    /**
-     * @var array
-     */
-    protected $extra = [];
-
-    /**
-     * Retrieve extra information that may have been parsed from the XML.
-     *
-     * @param string|null $key
-     * @param mixed $default
-     * @return mixed
-     */
-    public function getExtra($key = null, $default = null): mixed
-    {
-        if ($key) {
-            return data_get($this->extra, $key, $default);
-        }
-
-        return $this->extra;
-    }
-
-    /**
-     * Check to see if a key is available in the extras array.
-     *
-     * @param string $key
-     * @return boolean
-     */
-    public function hasExtra($key)
-    {
-        return Arr::has($this->extra, $key);
-    }
-
-    /**
-     * Record an 'extra' value that was parsed from the XML.
-     *
-     * @param string $key
-     * @param mixed $value
-     * @return void
-     */
-    public function setExtra($key, $value): void
-    {
-        $this->extra = data_set($this->extra, $key, $value);
     }
 
     /**

--- a/app/Feeds/HasExtrasArray.php
+++ b/app/Feeds/HasExtrasArray.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Feeds;
+
+use App\Utilities\Arr;
+
+/**
+ * Methods for working with an array of 'extras' that may be captured from
+ * feed or entry XML but don't have a dedicated place in the Subscription
+ * or Article model format.
+ */
+trait HasExtrasArray
+{
+    /**
+     * @var array
+     */
+    protected $extra = [];
+
+    /**
+     * Retrieve extra information that may have been parsed from the XML.
+     *
+     * @param string|null $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public function getExtra($key = null, $default = null): mixed
+    {
+        if ($key) {
+            return data_get($this->extra, $key, $default);
+        }
+
+        return $this->extra;
+    }
+
+    /**
+     * Check to see if a key is available in the extras array.
+     *
+     * @param string $key
+     * @return boolean
+     */
+    public function hasExtra($key)
+    {
+        return Arr::has($this->extra, $key);
+    }
+
+    /**
+     * Record an 'extra' value that was parsed from the XML.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     */
+    public function setExtra($key, $value): void
+    {
+        $this->extra = data_set($this->extra, $key, $value);
+    }
+}

--- a/app/Feeds/Rss091/Entry.php
+++ b/app/Feeds/Rss091/Entry.php
@@ -4,8 +4,8 @@ namespace App\Feeds\Rss091;
 
 use App\Feeds\Entry as ParentEntry;
 use App\Feeds\Variants;
+use App\Utilities\Str;
 use App\Utilities\Xml;
-use SimpleXMLElement;
 
 class Entry extends ParentEntry
 {
@@ -19,6 +19,28 @@ class Entry extends ParentEntry
         // Attributes
         $this->summary = Xml::decode($this->xml->description);
         $this->title = Xml::decode($this->xml->title);
+
+        // Categories
+        $categories = collect();
+        foreach ($this->xml->category as $category) {
+            $label = Xml::decode($category);
+
+            if (empty($label)) {
+                continue;
+            }
+
+            // If the category contains a slash it represents a hierarchy
+            // https://www.rssboard.org/rss-0-9-2#ltcategorygtSubelementOfLtitemgt
+            // We won't automatically capitalize it.
+            if (! Str::contains($label, '/')) {
+                $label = ucwords($label);
+            }
+
+            $categories->push($label);
+        }
+        if ($categories->filter()->isNotEmpty()) {
+            $this->setExtra('categories', $categories->filter()->toArray());
+        }
 
         // Links
         $this->setExtra('links', Xml::links($this->xml));

--- a/app/Feeds/Rss091/Fake.php
+++ b/app/Feeds/Rss091/Fake.php
@@ -71,9 +71,10 @@ class Fake extends FakeFeed
      */
     protected function entryToString(array $entry): string
     {
-        $title = Arr::get($entry, 'title');
+        $categories = Arr::get($entry, 'categories', []);
         $linkToSource = Arr::get($entry, 'linkToSource');
         $summary = Arr::get($entry, 'summary');
+        $title = Arr::get($entry, 'title');
 
         $entry = <<<ENTRY
         <item>
@@ -83,6 +84,10 @@ class Fake extends FakeFeed
 
         if ($summary) {
             $entry .= "<description>{$summary}</description>";
+        }
+
+        foreach ($categories as $category) {
+            $entry .= "<category domain=\"http://example.com\">{$category}</category>";
         }
 
         $entry .= '</item>';

--- a/tests/Unit/Actions/Feeds/RecordArticleTest.php
+++ b/tests/Unit/Actions/Feeds/RecordArticleTest.php
@@ -18,7 +18,7 @@ class RecordArticleTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function it_creates_articles()
+    public function it_records_articles()
     {
         $user = User::factory()->create();
         $subscription = Subscription::factory()->create([
@@ -30,6 +30,7 @@ class RecordArticleTest extends TestCase
         Carbon::setTestNow($knownDate);
         $fake = Simulator::make()->withEntry([
             'authors' => [$author],
+            'categories' => ['cat3', 'cat4'],
             'content' => 'Content 1',
             'identifier' => 'guid1',
             'linkToSource' => 'example.com/link',
@@ -47,6 +48,7 @@ class RecordArticleTest extends TestCase
 
         $this->assertTrue($action->completed());
         $this->assertEquals([$author->toArray()], $action->article->getExtra('authors'));
+        $this->assertEquals(['Cat3', 'Cat4'], $action->article->getExtra('categories'));
         $this->assertEquals('<p>        Content 1    </p>', $action->article->content);
         $this->assertEquals('guid1', $action->article->identifier);
         $this->assertEquals('example.com/link', $action->article->link_to_source);

--- a/tests/Unit/Actions/Feeds/UpdateSubscriptionDefinitionTest.php
+++ b/tests/Unit/Actions/Feeds/UpdateSubscriptionDefinitionTest.php
@@ -28,6 +28,7 @@ class UpdateSubscriptionDefinitionTest extends TestCase
         ]);
         $fake = Simulator::make([
             'authors' => [$author],
+            'categories' => ['cat3', 'cat4'],
             'identifier' => '0123456789',
             'imageUrl' => 'https://picsum.photos/200/300',
             'linkToSource' => 'example.com',
@@ -47,6 +48,7 @@ class UpdateSubscriptionDefinitionTest extends TestCase
 
         $this->assertTrue($action->completed());
         $this->assertEquals('0123456789', $action->subscription->identifier);
+        $this->assertEquals(['Cat3', 'Cat4'], $action->subscription->getExtra('categories'));
         $this->assertNotEquals('original_checksum', $subscription->checksum);
         $this->assertEquals('example.com', $action->subscription->link_to_source);
         $this->assertEquals('example.com/feed', $action->subscription->link_to_feed);

--- a/tests/Unit/Feeds/SimulatedFeedReaderTest.php
+++ b/tests/Unit/Feeds/SimulatedFeedReaderTest.php
@@ -112,6 +112,7 @@ class SimulatedFeedReaderTest extends TestCase
                 'timestamp' => $knownDate,
             ])
             ->withEntry([
+                'categories' => ['cat1', 'cat2'],
                 'linkToSource' => 'example.com/link',
                 'title' => 'Example Entry Title',
                 'summary' => 'Summary 1',
@@ -139,6 +140,7 @@ class SimulatedFeedReaderTest extends TestCase
         $entries = $feed->getEntries();
         $this->assertCount(2, $entries);
         $this->assertNotEmpty($entries[0]->getIdentifier());
+        $this->assertEquals(['Cat1', 'Cat2'], $entries[0]->getExtra('categories'));
         $this->assertEquals('example.com/link', $entries[0]->getLinkToSource());
         $this->assertEquals('Summary 1', $entries[0]->getSummary());
         $this->assertEquals('Example Entry Title', $entries[0]->getTitle());


### PR DESCRIPTION
This PR adds 'category' capture to RSS 0.91 feeds, and it ensures that category
information is recorded on subscriptions and articles.  

Additionally I have extracted the methods for working with the `extras` array
into a dedicated trait.
